### PR TITLE
Update Makefile

### DIFF
--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -63,6 +63,7 @@ PROJECTS += mod-volume
 PROJECTS += modmeter
 PROJECTS += modspectre
 PROJECTS += notes-lv2
+PROJECTS += neural-amp-modeler-lv2
 #PROJECTS += pitchtracking-series # FIXME use qemu tricks
 PROJECTS += remaincalm-plugins
 PROJECTS += rkrlv2


### PR DESCRIPTION
Recently I have installed current release on USB. USB boot working smootly . But I want to add a new plugin (neural-amp-modeler-lv2) . As I see, it has already added to mod-plugin-builder. I am hopping this will be commited change and new new plugin will be added to new release.